### PR TITLE
Updates references of kirkstone branch to main

### DIFF
--- a/_docs/build/build.md
+++ b/_docs/build/build.md
@@ -38,7 +38,7 @@ Please refer to the following list to select the correct manifest file:
 |**yocto-arm64-tqma8mpxl-mba8mpxl.xml**|TQ-Systems TQMa8MPxL on MBa8MPxL SBC
 
 ```
-repo init -u https://github.com/gyroidos/gyroidos.git -b kirkstone -m <manifest file>
+repo init -u https://github.com/gyroidos/gyroidos.git -b main -m <manifest file>
 repo sync -j8
 ```
 

--- a/_docs/build/guestos.md
+++ b/_docs/build/guestos.md
@@ -26,7 +26,7 @@ In order to setup an environment for building guest operating systems only, foll
 * Initialize and synchronize the repo:
 
 ```
-repo init -u https://github.com/gyroidos/gyroidos.git -b kirkstone -m yocto-generic-container.xml
+repo init -u https://github.com/gyroidos/gyroidos.git -b main -m yocto-generic-container.xml
 repo sync -j8
 ```
 

--- a/_docs/operate/rattestation.md
+++ b/_docs/operate/rattestation.md
@@ -81,7 +81,7 @@ The following commands are run on the host, not the QEMU VM.
 
 1. Clone the [cml repository](https://github.com/gyroidos/cml/)
 2. Navigate to the `cml/rattestation` directory.
-3. Install the dependencies listed [in the README](https://github.com/glad-dev/cml/tree/kirkstone/rattestation#readme).
+3. Install the dependencies listed [in the README](https://github.com/gyroidos/cml/tree/main/rattestation#readme).
 4. Create the log directory with `mkdir /data/logs` or change `#define LOGFILE_DIR "/data/logs"` in `main.c`.
 5. Build the attestation tool with `make`.
 6. Extract the first certificate from the trust chain located at `ws-yocto/out-yocto/test_certificates/ssig_subca.cert` and save it as `yocto.pem`.


### PR DESCRIPTION
The documentation still references the kirkstone branch in some places. These instances have been updated to use the main branch instead.