### PR TITLE
Moves EWC25 to Talk section

### DIFF
--- a/_docs/talks/ewc25.md
+++ b/_docs/talks/ewc25.md
@@ -1,7 +1,7 @@
 ---
-title: Embedded World Conference 2025
-#category: General
-order: 4
+title: EWC 2025
+category: Talks
+order: 1
 ---
 
 


### PR DESCRIPTION
The EWC25 section currently has no a category, resulting in a blank space in the navigation bar. This PR assigns the EWC25 section to the "Talks" category and positioning it at the end of the navigation bar.